### PR TITLE
Makefile: fix compilation flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,18 @@
 #
 NAME = myprogram
 
-CFLAGS += -c -std=c++14 $(shell PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/ pkg-config --cflags libpistache)
-LDFLAGS += $(shell PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/ pkg-config --libs libpistache)
+# all possible lib search paths.
+LD_SEARCH=-Wl,-rpath,./ -Wl,-rpath,/usr/lib64 -Wl,-rpath,/usr/local/lib64/
+
+# try pkg-config in default and local-install paths
+MY_CFLAGS=$(shell pkg-config --cflags libpistache)
+MY_LDFLAGS=$(shell pkg-config --libs libpistache)
+ifeq ($(MY_CFLAGS),)
+    MY_CFLAGS=$(shell PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/ pkg-config --cflags libpistache)
+    MY_LDFLAGS=$(shell PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/ pkg-config --libs libpistache)
+endif
+CFLAGS += -c -std=c++14 $(MY_CFLAGS)
+LDFLAGS += $(MY_LDFLAGS) $(LD_SEARCH)
 
 .PHONY: pistache
 


### PR DESCRIPTION
try to detect local installation (provide /usr/local path to pkg-config)
link in all possible (consievable) library search paths (don't do in prod!)